### PR TITLE
abrirCaja actualizado

### DIFF
--- a/src/caja/caja.clase.ts
+++ b/src/caja/caja.clase.ts
@@ -160,7 +160,7 @@ export class CajaClase {
       console.log("time en caja.clase: ", res.time);
       if (res.estado==true) {
 	schCajas.getCambioDeTurno().then((res2) => {});
-        return parseInt(res.time);
+        return parseInt(res.time)+1000;
       } else {
        return Date.now();
       }


### PR DESCRIPTION
se ha aumentado un segundo la apertura de caja cuando ocurre un cambio de turno para que no coincidan la apertura con el cierre de la anterior caja.