### PR TITLE
tickets y sincro actualizados + console.logs quitados

### DIFF
--- a/src/instalador/instalador.controller.ts
+++ b/src/instalador/instalador.controller.ts
@@ -19,9 +19,9 @@ export class InstaladorController {
     @Body()
     { password, numLlicencia, tipoImpresora, tipoDatafono, impresoraCafeteria }
   ) {
-    console.log(password);
+
     try {
-      console.log('Hooa')
+
       if (
         password &&
         numLlicencia &&
@@ -33,7 +33,7 @@ export class InstaladorController {
           password,
           numLlicencia,
         });
-        console.log(resAuth);
+
         if (resAuth.data) {
           const objParams = parametrosInstance.generarObjetoParametros();
           axios.defaults.headers.common["Authorization"] = resAuth.data.token;

--- a/src/movimientos/movimientos.clase.ts
+++ b/src/movimientos/movimientos.clase.ts
@@ -166,7 +166,7 @@ export class MovimientosClase {
   }
 
   /* Eze 4.0 */
-  private calcularFormaPago(superTicket: SuperTicketInterface): FormaPago {
+  public calcularFormaPago(superTicket: SuperTicketInterface): FormaPago {
     if (superTicket.consumoPersonal) return "CONSUMO_PERSONAL";
 
     if (superTicket.movimientos.length === 1) {

--- a/src/paytef/paytef.class.ts
+++ b/src/paytef/paytef.class.ts
@@ -9,7 +9,6 @@ import { io } from "../sockets.gateway";
 import { logger } from "../logger";
 import * as schTickets from "../tickets/tickets.mongodb";
 
-
 class PaytefClass {
   /* Eze 4.0 */
   async iniciarTransaccion(
@@ -41,8 +40,9 @@ class PaytefClass {
         timeout: 30000,
       })
         .then(async (respuestaPayef: any) => {
-          if (await respuestaPayef.data.info['started'])
+          if (await respuestaPayef.data.info['started']){
             await this.bucleComprobacion(idTicket, total, idTrabajador, type);
+          }
           else {
             io.emit("consultaPaytefRefund", {ok:false, id:idTicket});
             logger.Error(137, "Error, la transacción no ha podido empezar paytef.class");
@@ -85,6 +85,7 @@ class PaytefClass {
             idTicket,
             idTrabajador
           );
+          schTickets.actualizarEnviadoTicket(idTicket);
           io.emit("consultaPaytef", true);
         } else if (type === "refund") {
           schTickets.anularTicket(idTicket);

--- a/src/tickets/tickets.mongodb.ts
+++ b/src/tickets/tickets.mongodb.ts
@@ -163,7 +163,22 @@ export async function actualizarEstadoTicket(
     )
   ).acknowledged;
 }
-
+export async function actualizarEnviadoTicket(
+  idTicket: TicketsInterface["_id"]
+): Promise<boolean> {
+  const database = (await conexion).db("tocgame");
+  const tickets = database.collection<TicketsInterface>("tickets");
+  return (
+    await tickets.updateOne(
+      { _id: idTicket },
+      {
+        $set: {
+          enviado: false,
+        },
+      }
+    )
+  ).acknowledged;
+}
 /* Eze v4 */
 export async function setTicketEnviado(
   idTicket: TicketsInterface["_id"]

--- a/src/traducciones/traducciones.clase.ts
+++ b/src/traducciones/traducciones.clase.ts
@@ -64,7 +64,6 @@ export class Traducciones {
             
             return axios.post('traducciones/setTraduccionesKeys', traducciones)
                 .then(({ data }) => {
-                    console.log(data)
                     this.getTraducciones();
                     return data;
                 })


### PR DESCRIPTION
- se ha modificado sincronizarTickets para que se envie el ticket con el tipoPago al santaana.
- mientras se está pagando el ticket desde el datáfono, ya ha sido enviado al santAana con tipoPago efectivo. Al terminar la operación del datáfono, se modificará el campo 'enviado' del ticket a false para volver a enviar el ticket al santaAna pero con el tipoPago Tarjeta. Se borrará el anterior registro de este ticket por el actual.
- se han borrado los console.logs del instalador y traducciones