### PR TITLE
No duplicar tickets

### DIFF
--- a/src/sincro.ts
+++ b/src/sincro.ts
@@ -27,11 +27,10 @@ async function sincronizarTickets() {
         if (ticket) {
           nuevaInstancePromociones.deshacerPromociones(ticket);
           const res = await axios.post("tickets/enviarTicket", { ticket });
-
           if (res.data) {
             if (await ticketsInstance.setTicketEnviado(ticket._id)){
               enProcesoTickets = false;
-              setTimeout(sincronizarTickets, 200);
+              setTimeout(sincronizarTickets, 100);
             }else{
               enProcesoTickets=false;
             }

--- a/src/sincro.ts
+++ b/src/sincro.ts
@@ -17,9 +17,9 @@ import { nuevaInstancePromociones } from "./promociones/promociones.clase";
 let enProcesoTickets = false;
 let enProcesoMovimientos = false;
 
-async function sincronizarTickets(continuar: boolean = false) {
+async function sincronizarTickets() {
   try {
-    if (!enProcesoTickets || continuar) {
+    if (!enProcesoTickets) {
       enProcesoTickets = true;
       const parametros = await parametrosInstance.getParametros();
       if (parametros != null) {
@@ -31,7 +31,7 @@ async function sincronizarTickets(continuar: boolean = false) {
           if (res.data) {
             if (await ticketsInstance.setTicketEnviado(ticket._id)){
               enProcesoTickets = false;
-              setTimeout(function(){sincronizarTickets(true)}, 200);
+              setTimeout(sincronizarTickets, 200);
             }else{
               enProcesoTickets=false;
             }

--- a/src/sincro.ts
+++ b/src/sincro.ts
@@ -29,15 +29,16 @@ async function sincronizarTickets(continuar: boolean = false) {
           const res = await axios.post("tickets/enviarTicket", { ticket });
 
           if (res.data) {
-            if (await ticketsInstance.setTicketEnviado(ticket._id))
+            if (await ticketsInstance.setTicketEnviado(ticket._id)){
+              enProcesoTickets = false;
               sincronizarTickets(true);
+            }
           }
         }
       } else {
         logger.Error(4, "No hay parámetros definidos en la BBDD");
       }
     }
-    enProcesoTickets = false;
   } catch (err) {
     enProcesoTickets = false;
     logger.Error(5, err);

--- a/src/sincro.ts
+++ b/src/sincro.ts
@@ -31,9 +31,15 @@ async function sincronizarTickets(continuar: boolean = false) {
           if (res.data) {
             if (await ticketsInstance.setTicketEnviado(ticket._id)){
               enProcesoTickets = false;
-              sincronizarTickets(true);
+              setTimeout(function(){sincronizarTickets(true)}, 200);
+            }else{
+              enProcesoTickets=false;
             }
+          }else{
+            enProcesoTickets=false;
           }
+        }else{
+          enProcesoTickets=false;
         }
       } else {
         logger.Error(4, "No hay parámetros definidos en la BBDD");


### PR DESCRIPTION
se ha aumentado el tiempo de llamada al santaana a una decima de segundo con el setimeout para evitar tickets duplicados por insertar tickets a una velocidad muy rápida.
Tambien se ha quitado la variable continuar para evitar llamadas simultaneas al santaana.