### PR TITLE
upd imprimir deudas

### DIFF
--- a/src/deudas/deudas.mongodb.ts
+++ b/src/deudas/deudas.mongodb.ts
@@ -114,6 +114,7 @@ export async function getIntervaloDeuda(
   return await deudas
     .find({
       timestamp: { $lte: fechaFinal, $gte: fechaInicial },
+      nombreCliente: { $ne: null },
       estado: "SIN_PAGAR",
     })
     .toArray();


### PR DESCRIPTION
al imprimir deudas, el intervalo usado no obtendrá las deudas que no tengan un nombre cliente