### PR TITLE
upd actualizarCliente y ticket

### DIFF
--- a/src/tickets/tickets.mongodb.ts
+++ b/src/tickets/tickets.mongodb.ts
@@ -210,11 +210,15 @@ export async function getTotalLocal3G() {
 
 /* Eze v23 */
 export async function nuevoTicket(ticket: TicketsInterface): Promise<boolean> {
-  // conexion con mongo
   const database = (await conexion).db("tocgame");
   const tickets = database.collection<TicketsInterface>("tickets");
-  // insertar ticket
-  return (await tickets.insertOne(ticket)).acknowledged;
+
+  // Insertar ticket y esperar que se escriba en el journal
+
+  const result = await tickets.insertOne(ticket, {
+    writeConcern: { j: true },
+  });
+  return result.acknowledged;
 }
 
 /* Uri */


### PR DESCRIPTION
Se modificó la función actualizarCliente para que envíe únicamente los cambios en los campos específicos. En cuanto a los tickets, buscamos garantizar que el registro almacenado en MongoDB quede efectivamente persistido en el disco, evitando pérdidas en caso de un apagado inesperado.